### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ repositories {
 }
 
 dependencies {
-  compile 'com.github.ppamorim:dragger:1.2'
+  implementation 'com.github.ppamorim:dragger:1.2'
 }
 ```
 
@@ -143,7 +143,7 @@ You must use the [Android-ObservableScrollView][13], like this:
 
 ```groovy
 dependencies {
-  compile 'com.github.ksoichiro:android-observablescrollview:VERSION'
+  implementation 'com.github.ksoichiro:android-observablescrollview:VERSION'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.